### PR TITLE
#4: JSON stringification is always done by query-string (closes #4)

### DIFF
--- a/stateParams.js
+++ b/stateParams.js
@@ -7,7 +7,7 @@ const getDefaultParamTypes = order => {
     matchString: t.Object.is,
     matchInstance: t.Object.is,
     parse: x => parseParams(order)(x),
-    stringify: identity // if you use `JSON.stringify` `encodeURIComponent` fails to recognize it as an object and treats it as a string
+    stringify: x => stringifyParams(order)(x) // if you use `JSON.stringify` `encodeURIComponent` fails to recognize it as an object and treats it as a string
   };
 
   const string = {


### PR DESCRIPTION
Issue #4
## Test Plan
### tests performed

tested on LOL with @francescogior :
- `date-time` inside an object is correctly stringified
### tests not performed (domain coverage)
- object inside object is currently not supported (this is true for bot `parse` and `stringify`)
