### PR TITLE
#13: fix `magicIgnoreParam` regression from #11 (closes #13)

### DIFF
--- a/src/routerDiff.js
+++ b/src/routerDiff.js
@@ -73,7 +73,7 @@ export default function routerDiff({
   const parseParams = _parseParams(paramsParsers);
   const stringifyParams = _stringifyParams(paramsParsers);
 
-  const omitForQuery = [magicIgnoreParam, routerStateKey].concat(routerStatePathParamKeys);
+  const omitForQuery = [routerStateKey].concat(routerStatePathParamKeys);
 
   function maybePatchRouter(router) {
     if (!router.makeHrefPatch) {
@@ -148,7 +148,7 @@ export default function routerDiff({
           params: encodeParams(stringifyParams(pick(newState, routerStatePathParamKeys))),
           // react-router doesn't encode path params,
           // but only query params
-          query: stringifyParams(omit(newState, omitForQuery))
+          query: stringifyParams(omit(newState, omitForQuery.concat(magicIgnoreParam)))
         };
         if (shouldRouterPatchBePushed(currentRouterState, nextRouterState)) {
           log('pushState (transitionTo)', nextRouterState.state, nextRouterState.params, nextRouterState.query);


### PR DESCRIPTION
Issue #13

## Test Plan

### tests performed

qia redirect now works

screenshots:

**before regression**
<img width="673" alt="screen shot 2017-02-13 at 3 42 27 pm" src="https://cloud.githubusercontent.com/assets/2643520/22891249/a0efa4e4-f206-11e6-8d7c-85767769490a.png">

**after regression**
<img width="671" alt="screen shot 2017-02-13 at 3 44 54 pm" src="https://cloud.githubusercontent.com/assets/2643520/22891277/b90dfada-f206-11e6-832a-7c2117ec5a00.png">

**after this fix**
<img width="659" alt="screen shot 2017-02-13 at 4 05 03 pm" src="https://cloud.githubusercontent.com/assets/2643520/22891288/c373183e-f206-11e6-800e-ee0cf547cc68.png">


### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
